### PR TITLE
Ignore unknow flags for upgrade

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -90,6 +90,9 @@ func newChartCommand() *cobra.Command {
 			}
 			return diff.run()
 		},
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
 	}
 
 	f := cmd.Flags()


### PR DESCRIPTION
This PR is meant for people who simply removing diff from the command line, ignoring unknown flags to 'diff', e.g. --atomic

It allows to run helm diff upgrade --atomic ... without getting Error: unknown flag: --atomic.